### PR TITLE
Add a nix flake to support nix devshells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ __pycache__
 .py[ocd]
 
 /dist
+
+/.direnv
+/.envrc
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1747958103,
+        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,62 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      pkgs = forAllSystems (system: nixpkgs.legacyPackages.${system});
+
+    in
+    {
+      devShells = forAllSystems (system: {
+        default = pkgs.${system}.mkShellNoCC {
+          packages = with pkgs.${system}; [
+            (python313.withPackages (
+              ppkgs: with ppkgs; [
+                anyio
+                click
+                idna
+                iniconfig
+                jinja2
+                markdown
+                markupsafe
+                mypy-extensions
+                packaging
+                pathspec
+                platformdirs
+                pluggy
+                pytest
+                python-frontmatter
+                pyyaml
+                ruff
+                sniffio
+              ]
+            ))
+            mask
+          ];
+        };
+
+      });
+      packages = forAllSystems (
+        system:
+        let
+          sps = pkgs.${system};
+        in
+        {
+          alive = sps.python313Packages.alive-progress.overrideAttrs ({
+            postInstall = ''rm $out/LICENSE'';
+          });
+        }
+      );
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
                 pyyaml
                 ruff
                 sniffio
+                watchfiles
               ]
             ))
             mask


### PR DESCRIPTION
Adds a `flake.nix` file that allows for a reproducible devshell to be created using `nix develop` or [`nix-direnv`](https://github.com/nix-community/nix-direnv).
