### PR TITLE
ci: build with release mode for github pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: pip install -r requirements.txt
-      - run: python -m main-site
+      - run: python -m main-site build --release
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist/main-site


### PR DESCRIPTION
The github pages workflow wasn't minifying the files which happens with `--release`