### PR TITLE
fix: change body `min-width` to 0

### DIFF
--- a/main-site/public/css/common.css
+++ b/main-site/public/css/common.css
@@ -11,7 +11,7 @@ body {
 	background: var(--color-bg);
 	color: var(--color-fg);
 
-	min-width: 800px;
+	min-width: 0;
 	line-height: 1.4;
 }
 


### PR DESCRIPTION
We decided that lot's of wrapping is better than overflow. `min-width` also tends to cause weird bugs.
