### PR TITLE
feat: add a lang tag

### DIFF
--- a/main-site/templates/base.jinja
+++ b/main-site/templates/base.jinja
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="theme-dark">
+<html class="theme-dark" lang="en">
     <head>
         <meta charset="utf-8" />
 


### PR DESCRIPTION
Now I can put "Open Source Contributor" on my CV

Fixes #35. Strictly speaking as the domain is now runners.sh this is no longer needed but `lang="en"` is good for accessibility, among other things