### PR TITLE
feat: barcode cli

### DIFF
--- a/maskfile.md
+++ b/maskfile.md
@@ -72,3 +72,10 @@ pip freeze > requirements.txt
 ```sh
 python3 -m "$module" serve
 ```
+
+## barcode
+> Generate a random EAN-8 barcode
+
+```sh
+python3 -m runners_common barcode
+```

--- a/runners_common/__init__.py
+++ b/runners_common/__init__.py
@@ -1,2 +1,3 @@
 # ruff: noqa: F401 E402
 from . import funbar
+

--- a/runners_common/__main__.py
+++ b/runners_common/__main__.py
@@ -1,0 +1,32 @@
+import argparse
+import sys
+
+import solstice.log as log
+
+from . import funbar
+
+parser = argparse.ArgumentParser("solstice", description="")
+subparsers = parser.add_subparsers(title="subcommands", description="valid subcommands:", required=True, dest="cmd")
+
+barcode_parser = subparsers.add_parser(
+	"barcode", help="Generate a random barcode or a custom one"
+)
+barcode_parser.add_argument(
+	"code",
+	nargs="?",
+	help="A 7-digit number to generate a custom barcode, or nothing to generate a random one",
+)
+args = parser.parse_args()
+
+match args.cmd:
+	case "barcode":
+		if args.code is not None and len(args.code) == 7:
+			code = "".join(map(str, funbar.barcode_to_digits(args.code[0], num_digits=7)))
+		else:
+			if args.code is not None:
+				log.warn(
+					"argument given to barcode command should either be nonexistent for a random barcode or a number of length 7 to generate a custom one"
+				)
+			code = funbar.generate_rcn_barcode("./dist/main-site") # [TODO]: yikes
+		print(f"{code:08}")
+		sys.exit(0)

--- a/runners_common/funbar.py
+++ b/runners_common/funbar.py
@@ -111,11 +111,8 @@ def flush_barcode_cache():
 		file.writelines(f"{code:08}\n" for code in _barcode_cache)
 
 
-<<<<<<< HEAD:runners_common/funbar.py
+
 def generate_rcn_barcode(dist_path) -> Barcode:
-=======
-def generate_rcn_barcode() -> str:
->>>>>>> 59e1b69 (feat: barcode cli):solstice/funbar.py
 	"""
 	Generates a random RCN (private use) barcode.
 	"""
@@ -127,14 +124,9 @@ def generate_rcn_barcode() -> str:
 		# only 2 and 4 are valid RCN starting digits so just check a random bit to decide
 		first_digit = (2, 4)[integer >> 127]
 
-<<<<<<< HEAD:runners_common/funbar.py
-		barcode = first_digit * 1000000 + integer % 1000000
-		if barcode not in get_barcode_cache(dist_path):
-=======
 		barcode = f"{first_digit}{integer % 1000000:06}"
 		barcode += str(check_digit_for([*map(int, barcode)]))
-		if barcode not in get_barcode_cache():
->>>>>>> 59e1b69 (feat: barcode cli):solstice/funbar.py
+		if barcode not in get_barcode_cache(dist_path):
 			return barcode
 
 	raise RuntimeError(

--- a/runners_common/funbar.py
+++ b/runners_common/funbar.py
@@ -35,9 +35,9 @@ CENTER_GUARD_BAR = [1, 1, 1, 1, 1]
 type Barcode = int | str | list[int]
 
 
-def barcode_to_digits(barcode: Barcode) -> list[int]:
+def barcode_to_digits(barcode: Barcode, num_digits=8) -> list[int]:
 	if type(barcode) is int:
-		barcode = f"{barcode:08}"
+		barcode = str(barcode).zfill(num_digits)
 	if type(barcode) is str:
 		barcode = [*map(int, barcode)]
 
@@ -111,7 +111,11 @@ def flush_barcode_cache():
 		file.writelines(f"{code:08}\n" for code in _barcode_cache)
 
 
+<<<<<<< HEAD:runners_common/funbar.py
 def generate_rcn_barcode(dist_path) -> Barcode:
+=======
+def generate_rcn_barcode() -> str:
+>>>>>>> 59e1b69 (feat: barcode cli):solstice/funbar.py
 	"""
 	Generates a random RCN (private use) barcode.
 	"""
@@ -123,8 +127,14 @@ def generate_rcn_barcode(dist_path) -> Barcode:
 		# only 2 and 4 are valid RCN starting digits so just check a random bit to decide
 		first_digit = (2, 4)[integer >> 127]
 
+<<<<<<< HEAD:runners_common/funbar.py
 		barcode = first_digit * 1000000 + integer % 1000000
 		if barcode not in get_barcode_cache(dist_path):
+=======
+		barcode = f"{first_digit}{integer % 1000000:06}"
+		barcode += str(check_digit_for([*map(int, barcode)]))
+		if barcode not in get_barcode_cache():
+>>>>>>> 59e1b69 (feat: barcode cli):solstice/funbar.py
 			return barcode
 
 	raise RuntimeError(


### PR DESCRIPTION
Adds the barcode CLI that was discussed but never implemented

Usage:
```
# make barcode with custom prefix (generates the check digit)
> python3 -m main-site barcode 2345678
23456785
# generate random barcode
> python3 -m main-site barcode
46586889
```