### PR TITLE
fix: correct animation for blog posts in overview

### DIFF
--- a/main-site/public/css/blog-overview.css
+++ b/main-site/public/css/blog-overview.css
@@ -29,7 +29,8 @@ a.post-container {
 	}
 	&:hover:not(:active),
 	&:focus:not(:active) {
-		translate: calc(-0.5 * var(--shadowbox-spacing));
+		translate: calc(-0.5 * var(--shadowbox-spacing))
+			calc(-0.5 * var(--shadowbox-spacing));
 		&::after {
 			top: var(--shadowbox-spacing);
 			left: var(--shadowbox-spacing);


### PR DESCRIPTION
Blog post hover would only translate the item horizontally, this now no longer happens.
