### PR TITLE
fix: Zed formatter config reconciliation with pyproject.toml

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -5,14 +5,16 @@
 {
 	"languages": {
 		"Python": {
-			"language_servers": ["ruff", "pyright"]
-		},
-		"formatter": {
-			"code_actions_on_format": {
-				"source.fixAll.ruff": true,
-				"source.organizeImports.ruff": true
+			"language_servers": ["ruff", "pyright"],
+			"format_on_save": "on",
+			"formatter": {
+				"code_actions": {
+					"source.fixAll.ruff": true,
+					"source.organizeImports.ruff": true
+				}
 			}
 		},
+
 		"Markdown": {
 			"hard_tabs": true,
 			"tab_size": 4,


### PR DESCRIPTION
Moved the `"formatter"` under `"Python"`. This fixes the fighting between formatting produced by `ruff check` vs. auto-formatting on save in Zed.
