### PR TITLE
feat!: make solstice auto detect the caller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__
 .py[ocd]
 
 /dist
+*/dist
 
 /.direnv
 /.envrc

--- a/main-site/__main__.py
+++ b/main-site/__main__.py
@@ -3,11 +3,7 @@ from os import path
 from runners_common import funbar
 from solstice import *
 
-ssg = SiteGenerator(
-	__package__,  # type: ignore
-	output_path="../dist/main-site",
-)
-
+ssg = SiteGenerator(output_path="../dist/main-site")
 
 @cli.entrypoint(ssg)
 def build():

--- a/main-site/__main__.py
+++ b/main-site/__main__.py
@@ -44,3 +44,4 @@ def build():
 	posts.sort(key=lambda x: x["date"], reverse=True)
 
 	ssg.page("blog-overview.jinja", "blog/index.html", posts=posts)
+	

--- a/main-site/__main__.py
+++ b/main-site/__main__.py
@@ -5,6 +5,7 @@ from solstice import *
 
 ssg = SiteGenerator(output_path="../dist/main-site")
 
+
 @cli.entrypoint(ssg)
 def build():
 	ssg.copy("public")
@@ -22,9 +23,7 @@ def build():
 		src_path = path.join(dirname, file)
 		dist_path = path.join(dirname, name + ".html")
 		with MarkdownPage(ssg, "blog.jinja", src_path, dist_path) as pg:
-			posts.append(
-				pg.meta | {"url": "/" + dist_path.removesuffix(".html")}
-			)
+			posts.append(pg.meta | {"url": "/" + dist_path.removesuffix(".html")})
 
 			barcode = pg.meta.get("barcode")
 			if barcode is not None:
@@ -35,9 +34,7 @@ def build():
 					)
 				barcode_set[barcode] = src_path
 			if barcode is None:
-				warn(
-					f"Barcode not provided for {src_path}, using dummy barcode"
-				)
+				warn(f"Barcode not provided for {src_path}, using dummy barcode")
 				barcode = 69
 			pg.set_params(funbar=funbar.html_from_ean8(barcode))
 

--- a/main-site/e2e/conftest.py
+++ b/main-site/e2e/conftest.py
@@ -17,7 +17,7 @@ post_src = """
 title: Markdown widget gallery
 author: peppidesu & Cubic
 date: 1984-04-01
-barcode: 45322761
+barcode: ~~~BARCODE_SLOT~~~
 ---
 
 # Heading 1 <h1>
@@ -101,8 +101,8 @@ Weeeeee!
 def serve():
 	proc = subprocess.Popen(
 		[sys.executable, "-m", "main-site", "serve"],
-		stdout=subprocess.DEVNULL,
-		stderr=subprocess.DEVNULL,
+		# stdout=subprocess.DEVNULL,
+		# stderr=subprocess.DEVNULL,
 	)
 	sleep(1)
 	yield
@@ -129,12 +129,16 @@ def driver(serve):
 
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def blog_post():
+	global post_src
 	mod_dir = __import__("main-site").__path__[0]
 	blog_dir = f"{mod_dir}/blog"
+	barcode = subprocess.check_output("python -m runners_common barcode", shell=True, text=True).strip()
+	contents = post_src.strip().replace("~~~BARCODE_SLOT~~~", str(barcode))
+
 	with tempfile.NamedTemporaryFile(dir=blog_dir, suffix=".md", mode="w", encoding="utf-8") as f:
-		f.write(post_src.strip())
+		f.write(contents)
 		f.flush()
 		name = path.basename(f.name).removesuffix(".md")
 

--- a/main-site/e2e/conftest.py
+++ b/main-site/e2e/conftest.py
@@ -101,8 +101,8 @@ Weeeeee!
 def serve():
 	proc = subprocess.Popen(
 		[sys.executable, "-m", "main-site", "serve"],
-		# stdout=subprocess.DEVNULL,
-		# stderr=subprocess.DEVNULL,
+		stdout=subprocess.DEVNULL,
+		stderr=subprocess.DEVNULL,
 	)
 	sleep(1)
 	yield

--- a/main-site/e2e/test_gallery.py
+++ b/main-site/e2e/test_gallery.py
@@ -126,7 +126,6 @@ def environment():
 		driver.quit()
 
 
-
 def test_toc_heading_link_layers(environment):
 	driver, gallery_url = environment
 	driver.get(gallery_url)

--- a/runners_common/__init__.py
+++ b/runners_common/__init__.py
@@ -1,3 +1,2 @@
 # ruff: noqa: F401 E402
 from . import funbar
-

--- a/runners_common/__main__.py
+++ b/runners_common/__main__.py
@@ -6,11 +6,11 @@ import solstice.log as log
 from . import funbar
 
 parser = argparse.ArgumentParser("solstice", description="")
-subparsers = parser.add_subparsers(title="subcommands", description="valid subcommands:", required=True, dest="cmd")
-
-barcode_parser = subparsers.add_parser(
-	"barcode", help="Generate a random barcode or a custom one"
+subparsers = parser.add_subparsers(
+	title="subcommands", description="valid subcommands:", required=True, dest="cmd"
 )
+
+barcode_parser = subparsers.add_parser("barcode", help="Generate a random barcode or a custom one")
 barcode_parser.add_argument(
 	"code",
 	nargs="?",
@@ -27,6 +27,6 @@ match args.cmd:
 				log.warn(
 					"argument given to barcode command should either be nonexistent for a random barcode or a number of length 7 to generate a custom one"
 				)
-			code = funbar.generate_rcn_barcode("./dist/main-site") # [TODO]: yikes
+			code = funbar.generate_rcn_barcode("./dist/main-site")  # [TODO]: yikes
 		print(f"{code:08}")
 		sys.exit(0)

--- a/runners_common/funbar.py
+++ b/runners_common/funbar.py
@@ -82,6 +82,9 @@ _barcode_cache_path = None
 
 def get_barcode_cache(output_path: str):
 	global _barcode_cache, _barcode_cache_path
+
+	# TODO: implement barcode cache as a file
+	"""
 	if _barcode_cache is None:
 		_barcode_cache_path = path.join(output_path, path.pardir, "barcode_cache.txt")
 		try:
@@ -100,6 +103,8 @@ def get_barcode_cache(output_path: str):
 		import atexit
 
 		atexit.register(flush_barcode_cache)
+	"""
+	_barcode_cache = set()
 
 	return _barcode_cache
 

--- a/runners_common/funbar.py
+++ b/runners_common/funbar.py
@@ -6,10 +6,6 @@ The choice of EAN-8 is because it's horizontal, it fits in the narrow height of 
 [1]: https://ref.gs1.org/standards/genspecs/, 1.4.5 for RCN range, 5.2.1 for the EAN-8 specification
 """
 
-import os.path as path
-
-from solstice.log import warn
-
 # A = NUMBER_SETS[digit]
 # B = NUMBER_SETS[digit][::-1]
 # C = NUMBER_SETS[digit] # but C has the dark bars first
@@ -85,6 +81,9 @@ def get_barcode_cache(output_path: str):
 
 	# TODO: implement barcode cache as a file
 	"""
+	import os.path as path
+	from solstice.log import warn
+
 	if _barcode_cache is None:
 		_barcode_cache_path = path.join(output_path, path.pardir, "barcode_cache.txt")
 		try:
@@ -114,7 +113,6 @@ def flush_barcode_cache():
 		return
 	with open(_barcode_cache_path, "w") as file:
 		file.writelines(f"{code:08}\n" for code in _barcode_cache)
-
 
 
 def generate_rcn_barcode(dist_path) -> Barcode:

--- a/solstice/cli.py
+++ b/solstice/cli.py
@@ -12,9 +12,7 @@ def parse_cli():
 	Parse arguments from the CLI.
 	"""
 	parser = argparse.ArgumentParser("solstice", description="")
-	parser.add_argument(
-		"cmd", nargs="?", default="build", help='"build", "clean", or "serve"'
-	)
+	parser.add_argument("cmd", nargs="?", default="build", help='"build", "clean", or "serve"')
 	parser.add_argument("--release", action="store_true")
 	parser.add_argument("-p", "--port", default=5123, type=int)
 
@@ -54,9 +52,7 @@ def entrypoint(ssg: SiteGenerator):
 
 				ssg.clean()
 
-				thread = threading.Thread(
-					target=run_http_server, args=(args.port, ssg.output_path)
-				)
+				thread = threading.Thread(target=run_http_server, args=(args.port, ssg.output_path))
 				thread.start()
 
 				try:
@@ -119,9 +115,7 @@ def run_http_server(port, dir):
 				# Do not remove!
 				# Firefox also needs to be explicitly told to not cache anything with the following headers.
 				self.send_header("Connection", "close")
-				self.send_header(
-					"Cache-Control", "no-cache, no-store, must-revalidate"
-				)
+				self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
 				self.send_header("Pragma", "no-cache")
 				self.send_header("Expires", "0")
 				return super().end_headers()

--- a/solstice/cli.py
+++ b/solstice/cli.py
@@ -149,7 +149,7 @@ def hotreload(ssg: SiteGenerator, build_func: Callable):
 	from pygments import formatters, highlight, lexers
 	from watchfiles import watch  # type: ignore (removes pyright hallucination)
 
-	it = watch(ssg.module_path)  # file watcher
+	it = watch(ssg.project_dir)  # file watcher
 
 	# wait for server to start
 	while True:
@@ -165,7 +165,7 @@ def hotreload(ssg: SiteGenerator, build_func: Callable):
 		sys.stderr.write("\x1b[2J\x1b[H")  # clear screen, reset cursor
 
 		info(
-			f"Watching module {ssg.module_name} for changes. Visit website on http://localhost:{port}\n"
+			f"Watching path {ssg.project_dir} for changes. Visit website on http://localhost:{port}\n"
 		)
 
 		info(f"Starting build at {datetime.now()}")

--- a/solstice/sitegen.py
+++ b/solstice/sitegen.py
@@ -191,9 +191,7 @@ class SiteGenerator:
 		except FileNotFoundError:
 			warn("Nothing to clean.")
 
-	def page(
-		self, template_name: str, output_path: str | None = None, **kwargs
-	):
+	def page(self, template_name: str, output_path: str | None = None, **kwargs):
 		"""
 		Generate a page using the specified template and optionally an output path.
 		# Arguments

--- a/solstice/sitegen.py
+++ b/solstice/sitegen.py
@@ -62,16 +62,13 @@ class SiteGenerator:
 
 	```python
 	import solstice
-	ssg = solstice.SiteGenerator(__package__)
+	ssg = solstice.SiteGenerator()
 	ssg.page("index.jinja", title="Hello world!")
 	ssg.copy("public")
 	```
 	"""
 
-	module_name: str
-	""" Name of the current module """
-
-	module_path: str
+	project_dir: str
 	""" Path to the current module directory """
 
 	output_path: str
@@ -90,22 +87,24 @@ class SiteGenerator:
 
 	def __init__(
 		self,
-		module_name: str,
+		project_dir: str | None = None,
 		output_path: str | None = None,
 		templates_path: str | None = None,
 		profile: Literal["dev", "prod"] = "dev",
 	):
-		self.module_name = module_name
+		if project_dir is None:
+			import inspect
 
-		# Python black magic to get the module path
-		self.module_path = __import__(module_name).__path__[0]
-		os.chdir(self.module_path)
+			# python magic to get the path of the caller
+			prev_frame = inspect.stack()[1]
+			project_dir = path.dirname(path.abspath(prev_frame.filename))
 
-		self.output_path = output_path or path.join(self.module_path, "dist")
+		self.project_dir = project_dir
+		os.chdir(self.project_dir)
 
-		self.templates_path = templates_path or path.join(
-			self.module_path, "templates"
-		)
+		self.output_path = output_path or "dist"
+
+		self.templates_path = templates_path or "templates"
 
 		self.profile = profile
 
@@ -205,7 +204,7 @@ class SiteGenerator:
 		# Example
 		```python
 		import solstice
-		ssg = solstice.SiteGenerator(__package__)
+		ssg = solstice.SiteGenerator()
 		ssg.page("home.jinja", output_path="index.html", title="Hello world!")
 		```
 		"""
@@ -230,7 +229,7 @@ class SiteGenerator:
 		# Example
 		```python
 		import solstice
-		ssg = solstice.SiteGenerator(__package__)
+		ssg = solstice.SiteGenerator()
 		ssg.markdown_page("blog.jinja", "posts/my_post.md", output_path="blog/my_post.html")
 		```
 		"""
@@ -247,7 +246,7 @@ class Page:
 	```python
 	import solstice
 
-	ssg = solstice.SiteGenerator(__package__)
+	ssg = solstice.SiteGenerator()
 	with solstice.Page(ssg, "index.jinja") as page:
 		page.set_params(title="Hello world!")
 
@@ -281,7 +280,7 @@ class Page:
 		# Example
 		```python
 		import solstice
-		ssg = solstice.SiteGenerator(__package__)
+		ssg = solstice.SiteGenerator()
 		with solstice.Page(ssg, "index.jinja") as page:
 			page.set_params(
 				title="Hello world!",
@@ -345,7 +344,7 @@ class MarkdownPage(Page):
 	```python
 	import solstice
 
-	ssg = solstice.SiteGenerator(__package__)
+	ssg = solstice.SiteGenerator()
 	with solstice.MarkdownPage(
 		ssg,
 		"blog.jinja",


### PR DESCRIPTION
QOL feature. Instead of 
```py
import solstice
ssg = solstice.SiteGenerator(__package__)
```
You can now do
```py
import solstice
ssg = solstice.SiteGenerator()
# or
ssg = solstice.SiteGenerator(project_dir="../foo/bar")
```
This also opens the door for single-file (non-module) sites.