### PR TITLE
feat: add flag called "hidden" to make blog posts unlisted

### DIFF
--- a/main-site/__main__.py
+++ b/main-site/__main__.py
@@ -26,9 +26,10 @@ def build():
 		src_path = path.join(dirname, file)
 		dist_path = path.join(dirname, name + ".html")
 		with MarkdownPage(ssg, "blog.jinja", src_path, dist_path) as pg:
-			posts.append(
-				pg.meta | {"url": "/" + dist_path.removesuffix(".html")}
-			)
+			if not pg.meta.get("hidden", False):
+				posts.append(
+					pg.meta | {"url": "/" + dist_path.removesuffix(".html")}
+				)
 
 			barcode = pg.meta.get("barcode")
 			if barcode is not None:

--- a/main-site/blog/cat_states.md
+++ b/main-site/blog/cat_states.md
@@ -3,6 +3,7 @@ title: Cat States
 author: itepastra
 date: 2025-05-26
 barcode: 20028862
+hidden: true
 ---
 
 ## Classical cat states

--- a/main-site/blog/gallery.md
+++ b/main-site/blog/gallery.md
@@ -3,6 +3,7 @@ title: Markdown widget gallery
 author: peppidesu & Cubic
 date: 1984-04-01
 barcode: 45322761
+hidden: true
 ---
 
 # Heading 1 <h1>

--- a/main-site/blog/languages.md
+++ b/main-site/blog/languages.md
@@ -3,6 +3,7 @@ title: Programming Languages Gallery
 author: Cubic
 date: 2025-05-26
 barcode: 29015535
+hidden: true
 ---
 
 ```rs


### PR DESCRIPTION
Fixes #49

Blog posts with `hidden: true` in the frontmatter no longer show up in the blog list.

We should bikeshed the name (`hidden`? `unlisted`? etc)
