### PR TITLE
feat: better file reloading

### DIFF
--- a/main-site/__main__.py
+++ b/main-site/__main__.py
@@ -3,12 +3,10 @@ from os import path
 from runners_common import funbar
 from solstice import *
 
-ssg = SiteGenerator(
-	output_path="../dist/main-site", extra_watches=["../runners_common", "../solstice"]
-)
+ssg = SiteGenerator(output_path="../dist/main-site")
 
 
-@cli.entrypoint(ssg)
+@cli.entrypoint(ssg, extra_watches=["../runners_common", "../solstice"])
 def build():
 	ssg.copy("public")
 

--- a/main-site/__main__.py
+++ b/main-site/__main__.py
@@ -3,15 +3,20 @@ from os import path
 from runners_common import funbar
 from solstice import *
 
-ssg = SiteGenerator(output_path="../dist/main-site")
+ssg = SiteGenerator(
+	output_path="../dist/main-site", extra_watches=["../runners_common", "../solstice"]
+)
 
 
 @cli.entrypoint(ssg)
 def build():
 	ssg.copy("public")
-	ascii_logo = read_file("ascii/logo.asc")
-	ascii_name = read_file("ascii/name.asc")
-	ssg.page("index.jinja", ascii_logo=ascii_logo, ascii_name=ascii_name)
+
+	ssg.page(
+		"index.jinja",
+		ascii_logo=read_file("ascii/logo.asc"),
+		ascii_name=read_file("ascii/name.asc"),
+	)
 
 	posts = []
 

--- a/solstice/cli.py
+++ b/solstice/cli.py
@@ -27,7 +27,7 @@ def parse_cli():
 build_func: Any = None
 
 
-def entrypoint(ssg: SiteGenerator):
+def entrypoint(ssg: SiteGenerator, extra_watches: list[str] | None = None):
 	"""
 	`@cli.entrypoint` is used to mark the function that builds your site. It will wrap this function
 	into the CLI, calling it when building/hot-reloading.
@@ -69,7 +69,7 @@ def entrypoint(ssg: SiteGenerator):
 
 				build_func = func
 				try:
-					hotreload(ssg)
+					hotreload(ssg, extra_watches=extra_watches or [])
 				except KeyboardInterrupt:  # Ctrl+C, finalize
 					sys.stderr.write("\x1b[0J")  # clear from cursor down
 					sys.stderr.flush()
@@ -149,7 +149,7 @@ def run_http_server(port, dir):
 		_http_server_exception = sys.exception()
 
 
-def hotreload(ssg: SiteGenerator):
+def hotreload(ssg: SiteGenerator, extra_watches: list[str]):
 	import time
 	import traceback
 	from datetime import datetime
@@ -159,7 +159,7 @@ def hotreload(ssg: SiteGenerator):
 	import pygments.lexers
 	import watchfiles  # type: ignore (removes pyright hallucination)
 
-	it = watchfiles.watch(ssg.project_dir, *map(os.path.realpath, ssg.extra_watches))
+	it = watchfiles.watch(ssg.project_dir, *map(os.path.realpath, extra_watches))
 
 	# wait for server to start
 	while True:

--- a/solstice/cli.py
+++ b/solstice/cli.py
@@ -1,9 +1,11 @@
 import argparse
+import importlib
 import os
 import sys
-from typing import Callable
+from enum import Enum
+from typing import Any
 
-from .log import info
+from .log import info, warn
 from .sitegen import SiteGenerator
 
 
@@ -19,6 +21,10 @@ def parse_cli():
 	args = parser.parse_args()
 
 	return args
+
+
+# hot reloading requires build_func to be replaced so we can't use e.g. a function parameter to communicate it
+build_func: Any = None
 
 
 def entrypoint(ssg: SiteGenerator):
@@ -41,6 +47,12 @@ def entrypoint(ssg: SiteGenerator):
 	"""
 
 	def inner(func):
+		global build_func
+		# the hot reloading code calls importlib.reload which will rerun the entrypoint function; in that case we should just replace the function and not continue with the rest of the cli
+		if _http_server:
+			build_func = func
+			return
+
 		args = parse_cli()
 		match args.cmd:
 			case "build":  # Build the website
@@ -55,8 +67,9 @@ def entrypoint(ssg: SiteGenerator):
 				thread = threading.Thread(target=run_http_server, args=(args.port, ssg.output_path))
 				thread.start()
 
+				build_func = func
 				try:
-					hotreload(ssg, func)
+					hotreload(ssg)
 				except KeyboardInterrupt:  # Ctrl+C, finalize
 					sys.stderr.write("\x1b[0J")  # clear from cursor down
 					sys.stderr.flush()
@@ -70,6 +83,7 @@ def entrypoint(ssg: SiteGenerator):
 
 
 _http_server = None
+# if the http server thread crashes, this will be set to the exception so the other threads can gracefully fail
 _http_server_exception = None
 
 
@@ -135,15 +149,17 @@ def run_http_server(port, dir):
 		_http_server_exception = sys.exception()
 
 
-def hotreload(ssg: SiteGenerator, build_func: Callable):
+def hotreload(ssg: SiteGenerator):
 	import time
 	import traceback
 	from datetime import datetime
 
-	from pygments import formatters, highlight, lexers
-	from watchfiles import watch  # type: ignore (removes pyright hallucination)
+	import pygments
+	import pygments.formatters
+	import pygments.lexers
+	import watchfiles  # type: ignore (removes pyright hallucination)
 
-	it = watch(ssg.project_dir)  # file watcher
+	it = watchfiles.watch(ssg.project_dir, *map(os.path.realpath, ssg.extra_watches))
 
 	# wait for server to start
 	while True:
@@ -155,24 +171,75 @@ def hotreload(ssg: SiteGenerator, build_func: Callable):
 
 	_addr, port = _http_server.server_address
 
+	class ReloadType(Enum):
+		# no python should be reloaded, just run the function again
+		SOFT = 0
+		# the project python module should be reloaded
+		PROJECT = 1
+		# everything should be reloaded. this is used when `extra_watches` is passed to the ssg and a library is modified; solstice doesn't do advanced dependency tree detection shenanigans so we be conservative and reload the whole thing
+		FULL = 2
+
+		def __lt__(self, other):
+			return self.value < other.value
+
+	reload_type = ReloadType.SOFT
+
 	while True:
 		sys.stderr.write("\x1b[2J\x1b[H")  # clear screen, reset cursor
 
-		info(
-			f"Watching path {ssg.project_dir} for changes. Visit website on http://localhost:{port}\n"
-		)
+		info(f"Watching for changes. Visit website on http://localhost:{port}\n")
 
 		info(f"Starting build at {datetime.now()}")
 
+		if reload_type == ReloadType.PROJECT:
+			# find the module that corresponds to the project directory
+			try:
+				module = next(
+					module
+					for module in sys.modules.values()
+					if hasattr(module, "__path__")
+					and module.__path__[0].startswith(ssg.project_dir)
+				)
+
+				importlib.reload(module)
+
+				# now do a soft reload. this is technically redundant due to the code below but y'know, readability
+				reload_type = ReloadType.SOFT
+			except StopIteration:
+				warn("can't find the module, doing a full reload instead")
+				reload_type = ReloadType.FULL
+		if reload_type == ReloadType.FULL:
+			# incredibly cursed hack to get the actual argv of the process: https://stackoverflow.com/a/57914236
+			# sys.argv doesn't work as it doesn't consider command-line switches (e.g. -m)
+			import ctypes
+
+			argc = ctypes.c_int()
+			argv = ctypes.POINTER(ctypes.c_wchar_p)()
+			ctypes.pythonapi.Py_GetArgcArgv(ctypes.byref(argc), ctypes.byref(argv))
+
+			os.chdir(ssg.original_cwd)
+			os.execv(sys.executable, [argv[i] for i in range(argc.value)])
+			raise Exception("unreachable; see execv call")
+
+		# reload_type == ReloadType.SOFT
 		try:
 			build_func()
 		except BaseException:
-			# catch all exceptions to prevent hot-reload breakage, and output them in a similar fashion to stderr.
+			# catch all exceptions to prevent hot-reload breakage and output them to stderr
 			tb_text = "".join(traceback.format_exc())
-			lexer = lexers.get_lexer_by_name("pytb", stripall=True)
-			formatter = formatters.TerminalFormatter()
-			tb_colored = highlight(tb_text, lexer, formatter)
+			lexer = pygments.lexers.get_lexer_by_name("pytb", stripall=True)
+			formatter = pygments.formatters.TerminalFormatter()
+			tb_colored = pygments.highlight(tb_text, lexer, formatter)
 
 			print(tb_colored, file=sys.stderr)
 
-		next(it)  # wait for file changes
+		# wait for next change
+		item = next(it)
+
+		reload_type = ReloadType.SOFT
+		for _change_type, changed_path in item:
+			if changed_path.endswith(".py"):
+				if changed_path.startswith(ssg.project_dir):
+					reload_type = max(reload_type, ReloadType.PROJECT)
+				else:
+					reload_type = max(reload_type, ReloadType.FULL)

--- a/solstice/sitegen.py
+++ b/solstice/sitegen.py
@@ -86,9 +86,6 @@ class SiteGenerator:
 	original_cwd: str
 	""" The original working directory of the process when launched. """
 
-	extra_watches: list[str]
-	""" Files/directories to watch in addition to the main project directory."""
-
 	_md_instance: markdown.Markdown
 
 	def __init__(
@@ -96,7 +93,6 @@ class SiteGenerator:
 		project_dir: str | None = None,
 		output_path: str | None = None,
 		templates_path: str | None = None,
-		extra_watches: list[str] | None = None,
 		profile: Literal["dev", "prod"] = "dev",
 	):
 		if project_dir is None:
@@ -114,7 +110,6 @@ class SiteGenerator:
 
 		self.templates_path = templates_path or "templates"
 
-		self.extra_watches = extra_watches or []
 		self.profile = profile
 
 		self.jinja_env = jinja2.Environment(


### PR DESCRIPTION
WIP file reloading. Currently, if you spin up the dev server and change code in solstice or runners-common, it won't reload (as the files there aren't watched). This PR adds an argument so that those files are watched, plus functionality to reload the entire project in the case of e.g. changed code in solstice.
https://github.com/runners-sh/website/blob/93ce023efeeff2e1fbfb3e118c09ca02c209b861/main-site/__main__.py#L6-L8

The reloading logic is as follows:
- If non-Python files are changed, a soft reload is done (just rerun the build)
- If Python files are changed in `ssg.project_dir`, the module/script is reloaded and rerun.
- If Python files are changed outside of `ssg.project_dir`, the entire process, dev server and all, is restarted.

The feature is done but this PR is marked as draft as I'm not certain that this is the behavior we want to have.