### PR TITLE
feat: nicer inline code

### DIFF
--- a/main-site/public/css/blog-overview.css
+++ b/main-site/public/css/blog-overview.css
@@ -14,8 +14,6 @@ main {
 	}
 }
 
-
-
 img {
 	max-width: 100%;
 }

--- a/main-site/public/css/common.css
+++ b/main-site/public/css/common.css
@@ -122,6 +122,9 @@ code {
 	/* the fonts are already monospaced so */
 	font: inherit;
 	outline: 1px solid var(--color-fg-50);
+	padding: 1px;
+	margin: -1px;
+	background-color: var(--color-bg-10);
 }
 .codehilite code {
 	outline: none;
@@ -133,17 +136,12 @@ table:not(.codehilitetable) {
 		text-align: left;
 		padding: 8px;
 		padding-inline: 16px;
-		border-block: 1px solid
-			color-mix(in oklab, var(--color-fg) 50%, var(--color-bg));
+		border-block: 1px solid var(--color-fg-50);
 	}
 
 	thead > tr,
 	tr:nth-child(even) {
-		background-color: color-mix(
-			in oklab,
-			var(--color-fg) 8%,
-			var(--color-bg)
-		);
+		background-color: var(--color-bg-10);
 	}
 	border-collapse: collapse;
 }


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/0fcd4b3d-5e5e-43d7-8c24-3d5c1572721b)

after:
![image](https://github.com/user-attachments/assets/94531a03-9430-4eea-9c49-0813e85aa03a)

closes #50.